### PR TITLE
Fix audio duration if broken on load

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -112,6 +112,19 @@
           slider.value = (audio.currentTime / audio.duration) * 1000;
         }
       };
+      audio.oncanplaythrough = () => {
+        // In case audio duration is broken on load, force it to update
+        if (!isFinite(audio.duration)) {
+          const time = audio.currentTime;
+          audio.currentTime = 999999999;
+          setTimeout(() => {
+            audio.currentTime = time;
+            if (!isFinite(audio.duration)) {
+              audio.oncanplaythrough();
+            }
+          }, 1000);
+        }
+      }
       big_button.onclick = (event) => {
         if (last_played == -1) {
           play_buttons[0].onclick();


### PR DESCRIPTION
I ran into an [unfixed bug](https://bugs.chromium.org/p/chromium/issues/detail?id=642012) in Chromium browsers where the audio element's `duration` returns as `Infinity`, which breaks the seek functionality. This adds a check to the player when the audio is playable that forces the duration to get calculated if it is currently set to a non-finite number (I read that mobile browsers can sometimes return `NaN` instead of `Infinity`, so `isFinite()` handles both) by setting the current time to an unreasonably high number. The code is modified from [this answer on Stack Overflow](https://stackoverflow.com/a/52375280).

I tested and it works when loading the first track _and_ when changing tracks!