### PR TITLE
Read track # from ID3 tags & sort when added

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bandcamp is great (at time of writing,) but it would be great to have more optio
 - [x] reimport exported zip files for editing
 - [x] bulk import music or zip file of music/cover art
 - [x] auto parsing of music title from ID3 tags
-- [ ] auto parsing of music order from ID3 tags
+- [x] auto parsing of music order from ID3 tags
 - [x] custom css field
 - [ ] option to add additional files to the generated zip file (e.g. so one can set a background image through custom css)
 - [ ] option to re-encode audio to lower bitrate


### PR DESCRIPTION
I saw this on the roadmap list and figured I'd take a stab at it since it the tag library was already implemented! I'm not sure if this is what you had in mind, but:

- If the file has a `track` ID3 tag, it will use that to auto-sort the songs when they are added.
- If it doesn't have a `track` tag, it gets sorted to the end of the list as usual.
- If the song gets moved up or down, then the track number gets overridden by its current position in the list instead of retaining the track number it had when it was loaded.

Let me know if you want me to change anything!