### PR TITLE
Auto-update the generated player preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bandcamp is great (at time of writing,) but it would be great to have more optio
 - [x] custom css field
 - [ ] option to add additional files to the generated zip file (e.g. so one can set a background image through custom css)
 - [ ] option to re-encode audio to lower bitrate
-- [ ] auto-updating of the generated player
+- [x] auto-updating of the generated player
 - [ ] improve mobile support on itch.io. ostensibly only unity games are allowed to have dynamic sizing.
 
 ## serving

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,12 @@ const delegate = (root, selector, event, callback) => {
   });
 };
 
+for (const field of $$("[data-stored-key]")) {
+  field.onchange = () => {
+    make_preview();
+  }
+}
+
 let common_datastore = {};
 const isCheckable = tag => tag.type === 'checkbox' || tag.type === 'radio';
 const gather_fields = () => {
@@ -116,6 +122,7 @@ for (let color_picker of color_pickers) {
   color_picker.onblur = e => {
     iro_obj.el.classList.add("disabled");
     iro_obj.off("color:change", on_color_change);
+    make_preview();
   };
   on_color_change(color_picker.value);
 }
@@ -219,6 +226,7 @@ delegate(songs_list, '.song_remove', 'click', function (e) {
   const idx = Number(this.closest('.song').getAttribute('data-song-idx'));
   songs_datastore.splice(idx, 1);
   songs_rerender();
+  make_preview();
 });
 let current_sound;
 delegate(songs_list, '.song_set', 'click',function () {
@@ -234,6 +242,7 @@ change_song_input.onchange = async () => {
   current_sound = void 0;
   change_song_input.value = '';
   songs_rerender();
+  make_preview();
 };
 delegate(songs_list, '.song_title', 'change', function() {
   const idx = Number(this.closest('.song').getAttribute('data-song-idx'));
@@ -243,11 +252,13 @@ delegate(songs_list, '.song_up', 'click',function () {
   const idx = Number(this.closest('.song').getAttribute('data-song-idx'));
   [songs_datastore[idx], songs_datastore[idx - 1]] = [songs_datastore[idx - 1], songs_datastore[idx]];
   songs_rerender();
+  make_preview();
 });
 delegate(songs_list, '.song_down', 'click',function () {
   const idx = Number(this.closest('.song').getAttribute('data-song-idx'));
   [songs_datastore[idx], songs_datastore[idx + 1]] = [songs_datastore[idx + 1], songs_datastore[idx]];
   songs_rerender();
+  make_preview();
 });
 
 


### PR DESCRIPTION
This is my attempt to knock out the "auto-updating of the generated player" item on the roadmap. It just calls the `make_preview()` function whenever any of the form elements is changed. It's not as elegant or clever as it could be, but it works!