### PR TITLE
Audiobook features

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bandcamp is great (at time of writing,) but it would be great to have more optio
 - [ ] auto-updating of the generated player
 - [ ] improve mobile support on itch.io. ostensibly only unity games are allowed to have dynamic sizing.
 - [x] allow remembering position
-- [ ] allow setting playback rate
+- [x] allow setting playback rate
 
 ## serving
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ bandcamp is great (at time of writing,) but it would be great to have more optio
 - [ ] option to re-encode audio to lower bitrate
 - [ ] auto-updating of the generated player
 - [ ] improve mobile support on itch.io. ostensibly only unity games are allowed to have dynamic sizing.
+- [x] allow remembering position
+- [ ] allow setting playback rate
 
 ## serving
 

--- a/src/index.html
+++ b/src/index.html
@@ -51,6 +51,9 @@
         <div><label>
           <input type="checkbox" data-stored-scope="settings" data-stored-key="theme_transparent" /> leave background transparent in the exports
         </label></div>
+        <div><label>
+          <input type="checkbox" data-stored-scope="settings" data-stored-key="remember_position" /> remember where you left off
+        </label></div>
 
         <details class="well">
           <summary>custom css</summary>

--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,9 @@
         <div><label>
           <input type="checkbox" data-stored-scope="settings" data-stored-key="playback_rate" /> show playback rate
         </label></div>
+        <div style="margin-left: 20px;"><label>
+          <input type="checkbox" data-stored-scope="settings" data-stored-key="remember_rate" /> remember playback rate
+        </label></div>
 
         <details class="well">
           <summary>custom css</summary>

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,9 @@
         <div><label>
           <input type="checkbox" data-stored-scope="settings" data-stored-key="remember_position" /> remember where you left off
         </label></div>
+        <div><label>
+          <input type="checkbox" data-stored-scope="settings" data-stored-key="playback_rate" /> show playback rate
+        </label></div>
 
         <details class="well">
           <summary>custom css</summary>

--- a/src/index.js
+++ b/src/index.js
@@ -366,6 +366,12 @@ function generate(data, final) {
   };
   if (!final) {
     templateVars.theme_transparent = false;
+  } else {
+    // Generate a UUID for exports so localStorage can have a unique key
+    // UUID generator from https://stackoverflow.com/a/2117523
+    templateVars.uuid = "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+      (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    );
   }
   out = applyVarsToTemplate(out, templateVars);
   return out;

--- a/src/template.html
+++ b/src/template.html
@@ -100,7 +100,7 @@
           set_button_state(play_buttons[last_played], true);
         }
         <:if:playback_rate:>
-        audio.playbackRate = parseFloat(document.getElementById('playback_rate').value);
+        audio.playbackRate = parseFloat(document.getElementById("playback_rate").value);
         <:endif:playback_rate:>
       };
       audio.onpause = (event) => {
@@ -157,13 +157,13 @@
         set_button_state(e, false);
       });
       <:if:remember_position:>
-        const remember_key = 'remembered';
-      window.addEventListener('load', () => {
+      const remember_key = "<:uuid:>_remembered";
+      window.addEventListener("load", () => {
         let last = localStorage.getItem(remember_key) ?? null;
         if (!last) return;
         last = JSON.parse(last);
         const buttons = Array.from(play_buttons);
-        let button_idx = buttons.findIndex(b => b.getAttribute('data-song') == last.file);
+        let button_idx = buttons.findIndex(b => b.getAttribute("data-song") == last.file);
         if (button_idx < 0) return;
         const click_and_set_time = (idx, time, changed = false) => {
           play_buttons[idx].onclick();
@@ -185,10 +185,10 @@
             audio.onloadeddata = null;
           };
         };
-        const player = document.querySelector('.player');
-        const continue_prompt = document.createElement('button');
-        continue_prompt.style = 'padding:10px 20px;lineHeight:13pt;fontSize:12pt;';
-        continue_prompt.innerText = 'Continue where you left off';
+        const player = document.querySelector(".player");
+        const continue_prompt = document.createElement("button");
+        continue_prompt.style = "padding:10px 20px;lineHeight:13pt;fontSize:12pt;";
+        continue_prompt.innerText = "Continue where you left off";
         continue_prompt.onclick = (event) => {
           click_and_set_time(button_idx, last.time - 10);
           event.target.remove();
@@ -198,7 +198,7 @@
       window.position_checker = setInterval(() => {
         if (last_played < 0) return;
         const playing = play_buttons[last_played];
-        const file = playing.getAttribute('data-song');
+        const file = playing.getAttribute("data-song");
         if (!file) return;
         const time = Math.round(audio.currentTime);
         let last = localStorage.getItem(remember_key) ?? null;
@@ -211,7 +211,7 @@
       }, 10000);
       <:endif:remember_position:>
       <:if:playback_rate:>
-      const speed = document.getElementById('playback_rate');
+      const speed = document.getElementById("playback_rate");
       audio.preservesPitch = true;
       function set_playback_rate(value) {
         audio.playbackRate = parseFloat(value);
@@ -220,11 +220,11 @@
         <:endif:remember_rate:>
       }
       function set_speed_text(value) {
-        speed.parentElement.querySelector('span').innerHTML = 'Speed &times;' + value;
+        speed.parentElement.querySelector("span").innerHTML = "Speed &times;" + value;
       }
       <:if:remember_rate:>
-      const rate_key = 'playback_rate';
-      window.addEventListener('load', () => {
+      const rate_key = "<:uuid:>_playback_rate";
+      window.addEventListener("load", () => {
         let rate = localStorage.getItem(rate_key) ?? null;
         if (!rate) return;
         speed.value = rate;

--- a/src/template.html
+++ b/src/template.html
@@ -28,6 +28,12 @@
         <div class="player_tools">
           <p class="title"></p>
           <input type="range" min="0" max="1000" value="0" class="slider">
+          <:if:playback_rate:>
+          <label style="text-align:right;margin-top:5px;font-size:10pt;">
+            <span>Speed &times;1</span>
+            <input id="playback_rate" type="range" min="0.25" max="4" step="0.25" value="1" class="slider" style="max-width:150px;">
+          </label>
+          <:endif:playback_rate:>
         </div>
       </div>
       <ul class="song_list">
@@ -93,6 +99,9 @@
         if (last_played != -1) {
           set_button_state(play_buttons[last_played], true);
         }
+        <:if:playback_rate:>
+        audio.playbackRate = parseFloat(document.getElementById('playback_rate').value);
+        <:endif:playback_rate:>
       };
       audio.onpause = (event) => {
         set_button_state(big_button, false);
@@ -201,6 +210,16 @@
         localStorage.setItem(remember_key, JSON.stringify(position));
       }, 10000);
       <:endif:remember_position:>
+      <:if:playback_rate:>
+      const speed = document.getElementById('playback_rate');
+      audio.preservesPitch = true;
+      speed.oninput = (event) => {
+        speed.parentElement.querySelector('span').innerHTML = 'Speed &times;' + event.target.value;
+      };
+      speed.onchange = (event) => {
+        audio.playbackRate = parseFloat(event.target.value);
+      };
+      <:endif:playback_rate:>
     </script>
     <style type="text/css">
 body {

--- a/src/template.html
+++ b/src/template.html
@@ -147,6 +147,60 @@
         };
         set_button_state(e, false);
       });
+      <:if:remember_position:>
+        const remember_key = 'remembered';
+      window.addEventListener('load', () => {
+        let last = localStorage.getItem(remember_key) ?? null;
+        if (!last) return;
+        last = JSON.parse(last);
+        const buttons = Array.from(play_buttons);
+        let button_idx = buttons.findIndex(b => b.getAttribute('data-song') == last.file);
+        if (button_idx < 0) return;
+        const click_and_set_time = (idx, time, changed = false) => {
+          play_buttons[idx].onclick();
+          audio.onloadeddata = null;
+          audio.onloadeddata = (event) => {
+            if (time < 0) {
+              if (!changed) {
+                if (--idx < 0) {
+                  time = 0;
+                } else {
+                  return click_and_set_time(idx, time, true);
+                }
+              } else {
+                time = audio.duration + time;
+              }
+            }
+            audio.currentTime = Math.max(0, time);
+            audio.play();
+            audio.onloadeddata = null;
+          };
+        };
+        const player = document.querySelector('.player');
+        const continue_prompt = document.createElement('button');
+        continue_prompt.style = 'padding:10px 20px;lineHeight:13pt;fontSize:12pt;';
+        continue_prompt.innerText = 'Continue where you left off';
+        continue_prompt.onclick = (event) => {
+          click_and_set_time(button_idx, last.time - 10);
+          event.target.remove();
+        };
+        player.parentElement.insertBefore(continue_prompt, player);
+      }, { once: true });
+      window.position_checker = setInterval(() => {
+        if (last_played < 0) return;
+        const playing = play_buttons[last_played];
+        const file = playing.getAttribute('data-song');
+        if (!file) return;
+        const time = Math.round(audio.currentTime);
+        let last = localStorage.getItem(remember_key) ?? null;
+        if (last) {
+          last = JSON.parse(last);
+          if (last.file === file && last.time === time) return;
+        }
+        const position = { file, time };
+        localStorage.setItem(remember_key, JSON.stringify(position));
+      }, 10000);
+      <:endif:remember_position:>
     </script>
     <style type="text/css">
 body {

--- a/src/template.html
+++ b/src/template.html
@@ -213,11 +213,31 @@
       <:if:playback_rate:>
       const speed = document.getElementById('playback_rate');
       audio.preservesPitch = true;
+      function set_playback_rate(value) {
+        audio.playbackRate = parseFloat(value);
+        <:if:remember_rate:>
+        localStorage.setItem(rate_key, value);
+        <:endif:remember_rate:>
+      }
+      function set_speed_text(value) {
+        speed.parentElement.querySelector('span').innerHTML = 'Speed &times;' + value;
+      }
+      <:if:remember_rate:>
+      const rate_key = 'playback_rate';
+      window.addEventListener('load', () => {
+        let rate = localStorage.getItem(rate_key) ?? null;
+        if (!rate) return;
+        speed.value = rate;
+        set_playback_rate(rate);
+        set_speed_text(rate);
+        console.log(speed.value);
+      }, { once: true });
+      <:endif:remember_rate:>
       speed.oninput = (event) => {
-        speed.parentElement.querySelector('span').innerHTML = 'Speed &times;' + event.target.value;
+        set_speed_text(event.target.value);
       };
       speed.onchange = (event) => {
-        audio.playbackRate = parseFloat(event.target.value);
+        set_playback_rate(event.target.value);
       };
       <:endif:playback_rate:>
     </script>


### PR DESCRIPTION
Ok, I think this is the last pull request I'll create for this. Sorry for the deluge!

These features weren't on the roadmap, but I think they fit blamscamp well! They add 3 checkboxes that enable features that are good for audiobooks, namely:

- remembering where you left off
- setting the playback rate
- remembering the last playback rate you set

If "remember" is checked, it will add a check that runs every 10 seconds and saves the current file and position if it's changed, and when the page is reloaded after the position is saved, a button appears that lets you pick up where you left off. If you click the button, it takes you to the file and starts playing 10 seconds before the saved timestamp.

The playback rate options cause a speed slider to appear that adjusts in increments of 0.25 with a minimum value of 0.25 and a maximum value of 4 (because of the example provided on the [`HTMLMediaElement.playbackRate`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate) page). The remember playback rate checkbox just saves and loads the last rate that was set.

Anyway, thanks for blamscamp!