### PR TITLE
Add description field that accepts markdown

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
     <script type="text/javascript" src="jszip.min.js"></script>
     <script type="text/javascript" src="jsmediatags.min.js"></script>
     <script type="text/javascript" src="iro.min.js"></script>
+    <script type="text/javascript" src="md.min.js"></script>
     <link rel="stylesheet" href="index.css">
   </head>
   <body>
@@ -17,6 +18,13 @@
       <form id="editor">
         <div><input class="meta_fields" type="text" placeholder="album title" data-stored-key="album"/></div>
         <div><input class="meta_fields" type="text" placeholder="artist name" data-stored-key="artist"/></div>
+
+        <details class="well">
+          <summary>album description</summary>
+          <p style="text-align: right;"><small>accepts <a href="https://www.markdownguide.org/getting-started/">markdown</a></small></p>
+          <textarea class="code_editor" data-stored-key="description"></textarea>
+        </details>
+        
         <input class="hidden" type="file" accept="image/*" id="cover_input"/>
         <div class="well">
           <span class="cover_art"></span>

--- a/src/index.js
+++ b/src/index.js
@@ -504,6 +504,7 @@ function generate(data, final) {
     blamscamp_version: data.blamscamp_version,
     album: data.album,
     artist: data.artist,
+    description: md(data.description),
     cover: data.cover,
     songs: songs.join("\n"),
     ...data.settings

--- a/src/md.min.js
+++ b/src/md.min.js
@@ -1,0 +1,29 @@
+/**
+ * Copied from Feather Wiki:
+ * https://codeberg.org/Alamantus/FeatherWiki/src/commit/1e1bb77f42e057b53cd31acf0345612cbc51c6f4/helpers/md.js
+ * 
+ * Modified beyond recognition from md.js, a lightweight markdown parser
+ * https://github.com/thysultan/md.js
+ * 
+ * @licence MIT
+ */
+/**
+ * Supports Markdown Features:
+ * - HTML
+ * - headings h1–h6+ (# h1, ## h2, ### h3, etc.)
+ * - paragraphs (\n\n)
+ * - line breaks (  \n)
+ * - blockquotes (> text)
+ * - horizontal rule (---, ***, - - -, * * *)
+ * - code blocks (```)
+ * - inline code (`code`)
+ * - images with alt text & optional title (![alt](image_src "optional title"))
+ * - inline Markdown links with optional title ([link text](link_url "optional title"))
+ * - auto links & email linking (<http://url.domain>, <person@email.example>)
+ * - lists with indentation (- list item, * list item, + list item)
+ * - checkboxes ([ ], [x])
+ * - bold, italic (**bold**, __bold__, *italic*, _italic_, ***bold & italic***, ___bold & italic___, **_bold & italic_**, etc.)
+ * - strikethrough (~~strikethrough~~)
+ * - escaped characters (\*, \_)
+ */
+const charMap={"<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;",$:"&#36;","&":"&amp;","[":"&#91;","]":"&#93;","(":"&#40;",")":"&#41;",_:"&#95;","*":"&ast;","`":"&#96;"},doubleEscaped=Object.keys(charMap).filter((e=>"&"!=e)).map((e=>charMap[e].replace("&"!=e?"&":"",""))),htmlEntity=e=>e.replace(/[<>$&\(\)\[\]"']/g,(e=>charMap[e]||e)).replace(new RegExp(`&amp;(${doubleEscaped.join("|")})`,"g"),"&$1");function md(e){if(!e)return"";var l=[],t=0,c=[],n=0,r=e.length;let a;"\n"!==e[r-1]&&"\n"!==e[r-2]&&(e+="\n\n"),e=(e=e.replace(/\\(.)/g,((e,l)=>charMap[l]||e)).replace(/```(.*)\n([^\0]+?)```(?!```)/gm,((e,c,n)=>(l[t]={lang:c,block:htmlEntity(n)},`{code-${t++}}`))).replace(/`([^`]+?)`/g,((e,l)=>`<code>${htmlEntity(l)}</code>`)).replace(/<([^>\s]+(\/\/|@)[^>\s]+)>/g,((e,l,t)=>`[${l}](${"@"===t?"mailto:":""}${l})`)).replace(/(!?)\[([^\]]*?)\]\(([^\s\n]*)(?:| "(.*)")\)/gm,((e,l,t,c,n)=>{t=htmlEntity(t);try{c=decodeURI(c)}catch{}return c=encodeURI(c),n=n?` title="${htmlEntity(n)}"`:"",l?`<img src="${c}" alt="${t}"${n}>`:`<a href="${c}"${n}>${t}</a>`})).replace(/(<\/?[a-zA-Z]+[^>]*>)/gm,((e,l)=>(c[n]=l,`{html-${n++}}`))).replace(/^[ \t]*>+ (.*)/gm,"<blockquote>\n$1\n</blockquote>").replace(/(<\/blockquote>\n?<blockquote>)+?/g,"").replace(/^(#+) +(.*)/gm,((e,l,t)=>`<h${l.length}>${t}</h${l.length}>`)).replace(/^([^\n\t ])(.*)\n====+/gm,"<h1>$1$2</h1>").replace(/^([^\n\t ])(.*)\n----+/gm,"<h2>$1$2</h2>").replace(/\n( *[-*]){3,}\n/gm,"<hr>").replace(/\[( |x)\]/g,((e,l)=>`<input type="checkbox" disabled${"x"===l.toLowerCase()?" checked":""}>`)).replace(/  +\n/gm,"<br>").replace(/^([^-\+\*\d<\t \n])([^]*?)(?:\n\n)/gm,((e,l,t)=>`<p>${l}${t}</p>\n`))).replace(/^([\t ]*)(?:(-|\+|\*)|(\d+(?:\)|\.))) (.*)/gm,((e,l,t,c,n)=>{l.length>0&&!a?a=l.replace(/[^ ]/g,""):0===l.length&&a&&(a=void 0),a&&(l=l.replace(new RegExp(a,"g"),"\t"));const r=c?"o":"u";return`${l}<${r}l><li>${n}</li></${r}l>`}));for(var p=/<\/li><\/(u|o)l>\n(\t+)<(u|o)l><li>(.*)<\/li><\/(u|o)l>/;e.match(p);)e=e.replace(p,(function(e,l,t,c,n,r){return t.length>0&&(t=t.substring(1)).length>0&&(t="\n"+t),`${t}<${c}l><li>${n}</li></${r}l></li></${l}l>`}));e=e.replace(/(<\/ul>\n?[ \t]*<ul>)+?/g,"").replace(/(<\/ol>\n?[ \t]*<ol>)+?/g,"").replace(/\*\*([^\n*]+?)\*\*/g,"<strong>$1</strong>").replace(/__([^\n_]+?)__/g,"<strong>$1</strong>").replace(/\*([^\n*]+?)\*/g,"<em>$1</em>").replace(/_([^\n_]+?)_/g,"<em>$1</em>").replace(/(?:~~)([^~]+?)(?:~~)/g,"<del>$1</del>");for(let l=0;l<n;l++)e=e.replace(`{html-${l}}`,c[l]);for(let c=0;c<t;c++){const{lang:t,block:n}=l[c];e=e.replace(`{code-${c}}`,`<pre><code${t?` class="language-${t}"`:""}>${htmlEntity(n)}</code></pre>`)}return e.trim()}

--- a/src/template.html
+++ b/src/template.html
@@ -20,6 +20,9 @@
       <:if:artist:>
       <h3>by <span class="artist"><:artist:></span></h3>
       <:endif:artist:>
+      <:if:description:>
+      <div class="description"><:description:></div>
+      <:endif:description:>
       <div class="player">
         <button class="play loading">
           <svg class="icon">
@@ -59,7 +62,16 @@
     <:if:cover:>
     <div class="column_right">
       <img src="<:cover:>" class="cover"/>
+      <:if:description:>
+      <div class="description"><:description:></div>
+      <:endif:description:>
     </div>
+    <:else:cover:>
+    <:if:description:>
+    <div class="column_right">
+      <div class="description"><:description:></div>
+    </div>
+    <:endif:description:>
     <:endif:cover:>
     <script>
       function make_button(icon) {
@@ -290,6 +302,9 @@ body {
 .column_left {
   flex: 1 1 auto;
 }
+.column_left .description {
+  display: none;
+}
 
 .column_right {
   width: 250px;
@@ -303,6 +318,12 @@ body {
 
   .column_right {
     width: 100%;
+  }
+  .column_right .description {
+    display: none;
+  }
+  .column_left .description {
+    display: unset;
   }
 }
 
@@ -405,7 +426,7 @@ button.loading .icon {
   color: <:highlight_color:>;
 }
 
-h1, h2, h3, .player {
+h1, h2, h3, .player, .description {
   margin: 5px 10px;
 }
 


### PR DESCRIPTION
This lets you put an album description (or whatever text you want, i.e. links to other albums/whatever) below the album art on >500px screens or under the artist name on <=500px screens using Markdown for formatting. Note: to get this to display properly, the rendered description HTML is duplicated in both places but shown/hidden using CSS.

I added my own tiny Markdown parser that I [use in Feather Wiki](https://codeberg.org/Alamantus/FeatherWiki/src/commit/1e1bb77f42e057b53cd31acf0345612cbc51c6f4/helpers/md.js) (but minified) for parsing the description because it's quite small and handles all the basics: https://feather.wiki/?page=markdown_support. If you don't care about the size and would rather I use something more robust like MarkedJS, let me know and I can swap it out.