### PR TITLE
Add status classes for song list items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -231,7 +231,6 @@ add_songs_input.onchange = async e => {
   songs_datastore.sort((a, b) => {
     return track_key(a) - track_key(b);
   });
-  console.log(songs_datastore);
 
   songs_rerender();
   e.target.value = "";

--- a/src/template.html
+++ b/src/template.html
@@ -263,7 +263,6 @@
         speed.value = rate;
         set_playback_rate(rate);
         set_speed_text(rate);
-        console.log(speed.value);
       }, { once: true });
       <:endif:remember_rate:>
       speed.oninput = (event) => {

--- a/src/template.html
+++ b/src/template.html
@@ -69,6 +69,15 @@
         button.classList.add(playing === null ? "loading" : (playing ? "playing" : "paused"));
         button.classList.remove(...(playing === null ? ["playing", "paused"] : (playing ? ["paused", "loading"] : ["playing", "loading"])));
         button.innerHTML = make_button(playing === null ? "load" : (playing ? "pause" : "play"));
+        set_song_item_class(button, playing);
+      }
+      function set_song_item_class(button, playing) {
+        const li = button.closest("li");
+        if (li) {
+          li.classList.add(playing === null ? "loading" : (playing ? "playing" : "paused"));
+          li.classList.remove(...(playing === null ? ["playing", "paused"] : (playing ? ["paused", "loading"] : ["playing", "loading"])));
+          li.classList[!playing && play_buttons[last_played] === button ? "add" : "remove"]("last_played");
+        }
       }
       const audio = new Audio();
       const slider = document.querySelector(".slider");


### PR DESCRIPTION
This one's super self-indulgent for my own custom CSS wishes, so feel free to turn it down! It just adds CSS classes to the `li` element for the song item when a song begins playing or is paused. It also adds a `last_played` class when the button goes to `paused` so it can also be targeted more easily when you've paused a song after it's been playing.

Oh and one commit also removes some `console.log` calls that I'm pretty sure aren't supposed to be there. 🙂 