### PR TITLE
Make links in description use highlight color

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -449,7 +449,7 @@ button.loading .icon {
   margin: 0 5px;
 }
 
-.album, .artist, .title {
+.album, .artist, .title, a {
   color: <:highlight_color:>;
 }
 


### PR DESCRIPTION
I guess technically it makes links _anywhere_ that color too, but the only other link on the page is the blamscamp on GitHub, which has its own styling... So effectively just in the description 😄 